### PR TITLE
fix: add badges to tab labels in entities view

### DIFF
--- a/src/components/entities-view/__tests__/index.test.js
+++ b/src/components/entities-view/__tests__/index.test.js
@@ -98,19 +98,7 @@ describe('EntitiesView', () => {
       expect(screen.getByTitle('1 warning')).toBeInTheDocument();
     });
 
-    it('buckets NOT_ALERTING and NOT_CONFIGURED together into the healthy badge', () => {
-      render(
-        <EntitiesView
-          entities={[
-            entity({ guid: '1', alertSeverity: 'NOT_ALERTING' }),
-            entity({ guid: '2', alertSeverity: 'NOT_CONFIGURED' }),
-          ]}
-        />
-      );
-      expect(screen.getByTitle('2 healthy')).toBeInTheDocument();
-    });
-
-    it('shows all three badges when each severity bucket has entities', () => {
+    it('shows both badges when critical and warning entities are present', () => {
       render(
         <EntitiesView
           entities={[
@@ -122,10 +110,22 @@ describe('EntitiesView', () => {
       );
       expect(screen.getByTitle('1 critical')).toBeInTheDocument();
       expect(screen.getByTitle('1 warning')).toBeInTheDocument();
-      expect(screen.getByTitle('1 healthy')).toBeInTheDocument();
     });
 
-    it('omits a badge when that severity bucket is empty', () => {
+    it('shows no badges when all entities are healthy', () => {
+      render(
+        <EntitiesView
+          entities={[
+            entity({ guid: '1', alertSeverity: 'NOT_ALERTING' }),
+            entity({ guid: '2', alertSeverity: 'NOT_CONFIGURED' }),
+          ]}
+        />
+      );
+      expect(screen.queryByTitle(/critical/)).toBeNull();
+      expect(screen.queryByTitle(/warning/)).toBeNull();
+    });
+
+    it('omits the warning badge when there are no WARNING entities', () => {
       render(
         <EntitiesView
           entities={[entity({ guid: '1', alertSeverity: 'CRITICAL' })]}
@@ -133,7 +133,6 @@ describe('EntitiesView', () => {
       );
       expect(screen.getByTitle('1 critical')).toBeInTheDocument();
       expect(screen.queryByTitle(/warning/)).toBeNull();
-      expect(screen.queryByTitle(/healthy/)).toBeNull();
     });
   });
 
@@ -161,9 +160,8 @@ describe('EntitiesView', () => {
     const labels = screen
       .getAllByTestId(/nr1-Tab-label-/)
       .map((el) => el.textContent);
-    // First label should be for the HOST tab (contains "Host") since it's more severe.
-    expect(labels[0]).toMatch(/1/); // 1 entity in the first group
-    // The APPLICATION group ("APM Application" / Service - APM) is second.
-    expect(labels[1]).toMatch(/1/);
+    // HOST (CRITICAL) should sort before APPLICATION (NOT_ALERTING).
+    expect(labels[0]).toMatch(/[Hh]ost/);
+    expect(labels[1]).toMatch(/[Aa]pplication|Service/);
   });
 });

--- a/src/components/entities-view/__tests__/index.test.js
+++ b/src/components/entities-view/__tests__/index.test.js
@@ -75,6 +75,68 @@ describe('EntitiesView', () => {
     expect(screen.queryByText('Ghost')).toBeNull();
   });
 
+  describe('tab badges', () => {
+    it('shows a critical badge with the count of CRITICAL entities', () => {
+      render(
+        <EntitiesView
+          entities={[
+            entity({ guid: '1', alertSeverity: 'CRITICAL' }),
+            entity({ guid: '2', alertSeverity: 'CRITICAL' }),
+            entity({ guid: '3', alertSeverity: 'NOT_ALERTING' }),
+          ]}
+        />
+      );
+      expect(screen.getByTitle('2 critical')).toBeInTheDocument();
+    });
+
+    it('shows a warning badge for WARNING entities', () => {
+      render(
+        <EntitiesView
+          entities={[entity({ guid: '1', alertSeverity: 'WARNING' })]}
+        />
+      );
+      expect(screen.getByTitle('1 warning')).toBeInTheDocument();
+    });
+
+    it('buckets NOT_ALERTING and NOT_CONFIGURED together into the healthy badge', () => {
+      render(
+        <EntitiesView
+          entities={[
+            entity({ guid: '1', alertSeverity: 'NOT_ALERTING' }),
+            entity({ guid: '2', alertSeverity: 'NOT_CONFIGURED' }),
+          ]}
+        />
+      );
+      expect(screen.getByTitle('2 healthy')).toBeInTheDocument();
+    });
+
+    it('shows all three badges when each severity bucket has entities', () => {
+      render(
+        <EntitiesView
+          entities={[
+            entity({ guid: '1', alertSeverity: 'CRITICAL' }),
+            entity({ guid: '2', alertSeverity: 'WARNING' }),
+            entity({ guid: '3', alertSeverity: 'NOT_ALERTING' }),
+          ]}
+        />
+      );
+      expect(screen.getByTitle('1 critical')).toBeInTheDocument();
+      expect(screen.getByTitle('1 warning')).toBeInTheDocument();
+      expect(screen.getByTitle('1 healthy')).toBeInTheDocument();
+    });
+
+    it('omits a badge when that severity bucket is empty', () => {
+      render(
+        <EntitiesView
+          entities={[entity({ guid: '1', alertSeverity: 'CRITICAL' })]}
+        />
+      );
+      expect(screen.getByTitle('1 critical')).toBeInTheDocument();
+      expect(screen.queryByTitle(/warning/)).toBeNull();
+      expect(screen.queryByTitle(/healthy/)).toBeNull();
+    });
+  });
+
   it('sorts groups so higher-severity types come first', () => {
     render(
       <EntitiesView

--- a/src/components/entities-view/index.js
+++ b/src/components/entities-view/index.js
@@ -54,37 +54,33 @@ const SEVERITY_RANK = {
 const summarizeSeverity = (entities) => {
   let critical = 0;
   let warning = 0;
-  let healthy = 0;
   for (const e of entities) {
     if (e?.alertSeverity === 'CRITICAL') critical++;
     else if (e?.alertSeverity === 'WARNING') warning++;
-    else healthy++; // NOT_ALERTING, NOT_CONFIGURED, and any unknown value
   }
-  return { critical, warning, healthy };
+  return { critical, warning };
 };
 
 const TabLabel = ({ text, entities }) => {
-  const { critical, warning, healthy } = summarizeSeverity(entities);
+  const { critical, warning } = summarizeSeverity(entities);
+  const hasBadges = critical > 0 || warning > 0;
   return (
     <span className="tab-label">
       <span className="tab-label-name">{text}</span>
-      <span className="badges">
-        {critical > 0 && (
-          <span className="badge critical" title={`${critical} critical`}>
-            {critical}
-          </span>
-        )}
-        {warning > 0 && (
-          <span className="badge warning" title={`${warning} warning`}>
-            {warning}
-          </span>
-        )}
-        {healthy > 0 && (
-          <span className="badge healthy" title={`${healthy} healthy`}>
-            {healthy}
-          </span>
-        )}
-      </span>
+      {hasBadges && (
+        <span className="badges">
+          {critical > 0 && (
+            <span className="badge critical" title={`${critical} critical`}>
+              {critical}
+            </span>
+          )}
+          {warning > 0 && (
+            <span className="badge warning" title={`${warning} warning`}>
+              {warning}
+            </span>
+          )}
+        </span>
+      )}
     </span>
   );
 };

--- a/src/components/entities-view/index.js
+++ b/src/components/entities-view/index.js
@@ -51,6 +51,49 @@ const SEVERITY_RANK = {
   NOT_CONFIGURED: 0,
 };
 
+const summarizeSeverity = (entities) => {
+  let critical = 0;
+  let warning = 0;
+  let healthy = 0;
+  for (const e of entities) {
+    if (e?.alertSeverity === 'CRITICAL') critical++;
+    else if (e?.alertSeverity === 'WARNING') warning++;
+    else healthy++; // NOT_ALERTING, NOT_CONFIGURED, and any unknown value
+  }
+  return { critical, warning, healthy };
+};
+
+const TabLabel = ({ text, entities }) => {
+  const { critical, warning, healthy } = summarizeSeverity(entities);
+  return (
+    <span className="tab-label">
+      <span className="tab-label-name">{text}</span>
+      <span className="badges">
+        {critical > 0 && (
+          <span className="badge critical" title={`${critical} critical`}>
+            {critical}
+          </span>
+        )}
+        {warning > 0 && (
+          <span className="badge warning" title={`${warning} warning`}>
+            {warning}
+          </span>
+        )}
+        {healthy > 0 && (
+          <span className="badge healthy" title={`${healthy} healthy`}>
+            {healthy}
+          </span>
+        )}
+      </span>
+    </span>
+  );
+};
+
+TabLabel.propTypes = {
+  text: PropTypes.string.isRequired,
+  entities: PropTypes.array.isRequired,
+};
+
 const EntitiesView = ({
   entities,
   loading,
@@ -87,7 +130,12 @@ const EntitiesView = ({
           <TabsItem
             key={type}
             value={type}
-            label={`${entityTypeLabel(type)} (${groups.get(type).length})`}
+            label={
+              <TabLabel
+                text={entityTypeLabel(type)}
+                entities={groups.get(type)}
+              />
+            }
           >
             <div className="panel">
               <EntitiesTable

--- a/src/components/entities-view/styles.scss
+++ b/src/components/entities-view/styles.scss
@@ -61,11 +61,6 @@ $min-height: 320px;
         background: $status-warning;
         color: #5A4500;
       }
-      &.healthy {
-        background: transparent;
-        color: #687076;
-        border: 1px solid #C1C7CD;
-      }
     }
   }
 }

--- a/src/components/entities-view/styles.scss
+++ b/src/components/entities-view/styles.scss
@@ -25,3 +25,47 @@ $min-height: 320px;
     padding: 16px 4px 8px;
   }
 }
+
+.tab-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  .tab-label-name {
+    white-space: nowrap;
+  }
+
+  .badges {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 16px;
+      height: 16px;
+      border-radius: 4px;
+      font-size: 10px;
+      font-weight: 700;
+      font-variant-numeric: tabular-nums;
+      line-height: 1;
+      letter-spacing: 0;
+
+      &.critical {
+        background: $status-critical;
+        color: #FFFFFF;
+      }
+      &.warning {
+        background: $status-warning;
+        color: #5A4500;
+      }
+      &.healthy {
+        background: transparent;
+        color: #687076;
+        border: 1px solid #C1C7CD;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds badges showing the count of critical and/or warning entities to the `EntitiesView` tabs

<img width="4500" height="3000" alt="Screenshot of badges on EntitiesView tabs" src="https://github.com/user-attachments/assets/90a816e4-1f76-46b4-9d61-ebe4c085293f" />
